### PR TITLE
修复界面语言显示的错误

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -104,6 +104,7 @@ function confirmEmergencyStop() {
     cancel: {
       label: t('common.cancel'),
       color: 'dark',
+      textColor: 'white',
       flat: true,
       'no-caps': true
     }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -8,7 +8,7 @@ import ary from './locales/ary'
 
 const i18n = createI18n({
   legacy: false, // Set to false to use Composition API
-  locale: localStorage.getItem('language'),
+  locale: localStorage.getItem('language') || 'en', // Default to 'en' if no value in localStorage
   fallbackLocale: 'en', // Fallback language
   messages: {
     'zh-CN': zhCN,

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -167,7 +167,8 @@ export default {
       days: 'أيام ',
       hours: 'ساعات ',
       minutes: 'دقائق ',
-      seconds: 'ثواني '
+      seconds: 'ثواني ',
+      unknown:'مجهول'
     },
     deviceStatus: {
       title: 'حالة الأجهزة',

--- a/src/i18n/locales/ary.ts
+++ b/src/i18n/locales/ary.ts
@@ -167,7 +167,8 @@ export default {
       days: 'أيام ',
       hours: 'ساعات ',
       minutes: 'دقائق ',
-      seconds: 'ثواني '
+      seconds: 'ثواني ',
+      unknown:'مجهول'
     },
     deviceStatus: {
       title: 'حالة الأجهزة',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -167,7 +167,8 @@ export default {
       days: 'DAYS ',
       hours: 'HOURS ',
       minutes: 'MINUTES ',
-      seconds: 'SECONDS '
+      seconds: 'SECONDS ',
+      unknown:'UNKNOWN'
     },
     deviceStatus: {
       title: 'Device Status',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -167,7 +167,8 @@ export default {
       days: 'DÍAS ',
       hours: 'HORAS ',
       minutes: 'MINUTOS ',
-      seconds: 'SEGUNDOS '
+      seconds: 'SEGUNDOS ',
+      unknown:'DESCONHECIDO'
     },
     deviceStatus: {
       title: 'Estado de Dispositivos',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -167,7 +167,8 @@ export default {
       days: 'JOURS ',
       hours: 'HEURES ',
       minutes: 'MINUTES ',
-      seconds: 'SECONDES '
+      seconds: 'SECONDES ',
+      unknown:'INCONNU'
     },
     deviceStatus: {
       title: 'État des Appareils',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -167,7 +167,8 @@ export default {
       days: '天',
       hours: '小时',
       minutes: '分钟',
-      seconds: '秒'
+      seconds: '秒',
+      unknown:'未知'
     },
     deviceStatus: {
       title: '设备状态',

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -274,7 +274,7 @@ const formatDate = (timestamp) => {
 
 // 格式化运行时间
 const formatUptime = (hours) => {
-  if (!hours) return '未知';
+  if (!hours) return t('dashboard.systemStatus.unknown');
   
   const days = Math.floor(hours / 24);
   const remainingHours = Math.floor(hours % 24);

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -397,7 +397,7 @@ const filteredDevices = computed(() => {
 })
 
 // 当前语言
-const currentLanguage = ref(localStorage.getItem('language') || 'zh-CN')
+const currentLanguage = ref(localStorage.getItem('language') || 'en')
 
 // 处理语言切换
 const handleLanguageChange = (newLanguage: string) => {


### PR DESCRIPTION
修复首次启动时，DashBoard 界面在未连接服务器情况下，状态显示部分仍呈现中文的问题；同时解决设置界面在首次启动时默认显示为简体中文的错误。同时，将紧急关闭对话框中取消按钮的文本颜色修改为白色。

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the interface to correctly display the default language settings and improve localization strings across different languages by adding the translation for "unknown" and adjusting default locale settings.

### Why are these changes being made?
The updates fix incorrect default language display by setting the default locale to 'en' if none is stored and ensure consistency in language support by providing translations for the term "unknown" across all configured languages. This enhances user experience by ensuring clear language settings and comprehensive localization.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->